### PR TITLE
Allow skipping the cost function calculation

### DIFF
--- a/pybeads/__init__.py
+++ b/pybeads/__init__.py
@@ -3,7 +3,7 @@ from scipy.sparse import spdiags, dia_matrix, vstack
 from scipy.sparse.linalg import spsolve
 
 
-def beads(y, d, fc, r, Nit, lam0, lam1, lam2, pen, conv=None):
+def beads(y, d, fc, r, Nit, lam0, lam1, lam2, pen, conv=None, calc_cost=True):
     """
 
     Baseline estimation and denoising using sparsity (BEADS)
@@ -22,12 +22,16 @@ def beads(y, d, fc, r, Nit, lam0, lam1, lam2, pen, conv=None):
         conv: Smoothing factor for differential matrix D. This stabilizes
               outputs with slightly diffrent values for lam1 and lam2.
               Must be integer. 3 to 5 is recommended.
-              
+        calc_cost: Boolean that determines whether the cost function should
+              be evaluated each iteration. Default is True. Set to False
+              when a history of the cost function is not needed in order to
+              reduce calculation time.
+
 
     OUTPUT
         x: Estimated sparse-derivative signal.
         f: Estimated baseline.
-        cost: Cost function history
+        cost: Cost function history. An empty list if calc_cost is False.
 
     Reference:
         Chromatogram baseline estimation and denoising using sparsity (BEADS)
@@ -48,10 +52,10 @@ def beads(y, d, fc, r, Nit, lam0, lam1, lam2, pen, conv=None):
     EPS0 = 1e-6  # cost smoothing parameter for x (small positive value)
     EPS1 = 1e-6  # cost smoothing parameter for derivatives(small positive value)
 
-    if pen is 'L1_v1':
+    if pen == 'L1_v1':
         phi = lambda xx: np.sqrt(np.power(abs(xx), 2) + EPS1)
         wfun = lambda xx: 1. / np.sqrt(np.power(abs(xx), 2) + EPS1)
-    elif pen is 'L1_v2':
+    elif pen == 'L1_v2':
         phi = lambda xx: abs(xx) - EPS1 * np.log(abs(xx) + EPS1)
         wfun = lambda xx: 1. / (abs(xx) + EPS1)
     else:
@@ -95,13 +99,13 @@ def beads(y, d, fc, r, Nit, lam0, lam1, lam2, pen, conv=None):
         M = 2 * lam0 * Gamma + (D.transpose().dot(Lmda)).dot(D).transpose()
         x = A.dot(linv(BTB + A.transpose().dot(M.dot(A)), d))
 
-        a = y - x
-        cost.append(
-            0.5 * sum(abs(H(a)) ** 2)
-            + lam0 * theta(x)
-            + lam1 * sum(phi(np.diff(x.squeeze())))
-            + lam2 * sum(phi(np.diff(x.squeeze(), 2))))
-        pass
+        if calc_cost:
+            a = y - x
+            cost.append(
+                0.5 * sum(abs(H(a)) ** 2)
+                + lam0 * theta(x)
+                + lam1 * sum(phi(np.diff(x.squeeze())))
+                + lam2 * sum(phi(np.diff(x.squeeze(), 2))))
 
     f = y - x - H(y - x)
 


### PR DESCRIPTION
Added a calc_cost parameter to the main function that can be set to False to skip the cost function calculation to reduce calculation time when the cost function values are not needed. Addresses the second part of issue #1.